### PR TITLE
NettyTCPServer refactor and bug fixed

### DIFF
--- a/rainbow-skt/src/main/java/com/milchstrabe/rainbow/skt/server/typ3/tcp/NettyTCPServer.java
+++ b/rainbow-skt/src/main/java/com/milchstrabe/rainbow/skt/server/typ3/tcp/NettyTCPServer.java
@@ -11,7 +11,11 @@ import io.netty.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.NettyRuntime;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.UnorderedThreadPoolEventExecutor;
+import io.netty.util.internal.SystemPropertyUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -25,10 +29,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class NettyTCPServer {
 
+    // 默认业务线程数
+    private static final int DEFAULT_BUSY_LOOP_THREADS = Math.max(1, SystemPropertyUtil.getInt("io.netty.eventLoopThreads", NettyRuntime.availableProcessors() * 2));
+
     // 创建boss和worker
-    private final EventLoopGroup bossGroup = new NioEventLoopGroup(new DefaultThreadFactory("rainbow-skt-boosGroup"));
+    private final EventLoopGroup bossGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("rainbow-skt-boosGroup"));
     private final EventLoopGroup workerGroup = new NioEventLoopGroup(new DefaultThreadFactory("rainbow-skt-workGroup"));
-    private final EventLoopGroup busyGroup = new NioEventLoopGroup(new DefaultThreadFactory("rainbow-skt-busyGroup"));
+    private final EventExecutorGroup busyGroup = new UnorderedThreadPoolEventExecutor(DEFAULT_BUSY_LOOP_THREADS, new DefaultThreadFactory("rainbow-skt-busyGroup"));
 
     private Channel channel;
 

--- a/rainbow-skt/src/main/java/com/milchstrabe/rainbow/skt/server/typ3/tcp/NettyTCPServer.java
+++ b/rainbow-skt/src/main/java/com/milchstrabe/rainbow/skt/server/typ3/tcp/NettyTCPServer.java
@@ -11,6 +11,7 @@ import io.netty.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -25,9 +26,9 @@ import org.springframework.stereotype.Component;
 public class NettyTCPServer {
 
     // 创建boss和worker
-    private final EventLoopGroup bossGroup = new NioEventLoopGroup();
-    private final EventLoopGroup workerGroup = new NioEventLoopGroup();
-    private final EventLoopGroup busyGroup = new NioEventLoopGroup();
+    private final EventLoopGroup bossGroup = new NioEventLoopGroup(new DefaultThreadFactory("rainbow-skt-boosGroup"));
+    private final EventLoopGroup workerGroup = new NioEventLoopGroup(new DefaultThreadFactory("rainbow-skt-workGroup"));
+    private final EventLoopGroup busyGroup = new NioEventLoopGroup(new DefaultThreadFactory("rainbow-skt-busyGroup"));
 
     private Channel channel;
 

--- a/rainbow-skt/src/main/java/com/milchstrabe/rainbow/skt/server/typ3/tcp/NettyTCPServer.java
+++ b/rainbow-skt/src/main/java/com/milchstrabe/rainbow/skt/server/typ3/tcp/NettyTCPServer.java
@@ -78,9 +78,9 @@ public class NettyTCPServer {
      */
     public void destroy() {
         log.info("Shutdown Netty TCP Server...");
+        bossGroup.shutdownGracefully();
         if(channel != null) { channel.close();}
         workerGroup.shutdownGracefully();
-        bossGroup.shutdownGracefully();
         log.info("Shutdown Netty TCP Server Success!");
     }
 }


### PR DESCRIPTION
refactor
- naming EventLoopGroup is easy for troubleshooting
- bossGroup actually only use one thread, assign bossGroup thread number to save resource
- shutdown workerGroup firstly means that the bossGroup is still receiving the connection, but can't be registered with workerGroup.
shutdown bossGroup firstly means the connection is no longer received,that the client can retry to another service in advance,it's fail-fast.
other open source framework are similar implementations such as Dubbo.

fix
- the busyGroup implement NioEventLoopGroup only can use an identical eventExecutor,
`DefaultChannelPipeline.childExecutor()`method`ChannelOption.SINGLE_EVENTEXECUTOR_PER_GROUP`default true,so need get EventExecutor from `Map<EventExecutorGroup, EventExecutor> childExecutors = this.childExecutors;`the map key is EventExecutorGroup, so always return same eventExecutor